### PR TITLE
fix typo on io usage example

### DIFF
--- a/www/documentation/master/index.html
+++ b/www/documentation/master/index.html
@@ -258,7 +258,7 @@
 
 pub fn main() -&gt; %void {
     // If this program is run without stdout attached, exit with an error.
-    var stdout_file = %return std.io.getStdOut();
+    var stdout_file = %return io.getStdOut();
     const stdout = &amp;stdout_file.out_stream;
     // If this program encounters pipe failure when printing to stdout, exit
     // with an error.


### PR DESCRIPTION
Does this need updating in the 0.1.x dirs? Not sure of your strategy there.

fixes 

```
main.zig:5:31: error: use of undeclared identifier 'std'
    var stdout_file = %return std.io.getStdOut();
```

++ to https://github.com/zig-lang/www.ziglang.org/pull/2 if and when possible!