### PR TITLE
Provide a bit more information on release pages

### DIFF
--- a/www/download/index.html
+++ b/www/download/index.html
@@ -181,9 +181,6 @@
         </tbody>
       </table>
 
-
-      <br>
-      <p>You can also <a href="https://github.com/zig-lang/zig/wiki/Install-Zig-from-a-Package-Manager">install Zig from a package manager</a>.
       <br>
       <br>
       <br>

--- a/www/download/index.html
+++ b/www/download/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Releases &middot; The Zig Programming Language</title>
     <style type="text/css">
       #contents {
@@ -14,6 +15,21 @@
       }
       th, td {
         padding: 0.8em;
+        text-align: left;
+      }
+      th {
+        border-bottom: 2px solid #f2f3f3;
+      }
+      h2 {
+        background: #feebcd;
+        padding-left: 0.5em;
+      }
+      .code {
+        font-family: monospace;
+        font-size: 0.8em;
+      }
+      tr:nth-child(even) {
+        background: #f2f3f3;
       }
     </style>
   </head>
@@ -21,46 +37,151 @@
     <a href="/"><img src="../zig-logo.svg"></a>
     <div id="contents">
       <h1>Releases</h1>
+
+      <p>
+      Releases are provided in source and binary form. We currently recommend
+      the master binaries, as Zig is a fast moving target and there are many
+      improvements and fixes since 0.2.0.
+      </p>
+
+      <p>You can also <a href="https://github.com/zig-lang/zig/wiki/Install-Zig-from-a-Package-Manager">
+        install Zig from a package manager</a>.
+
+      <p><i>Note: MacOS is available through homebrew. See above.</i></p>
+
+      <br/>
+
+      <h2 id="release-master">Master</h2>
+      <ul>
+        <li><a href="/documentation/master">Documentation</a></li>
+      </ul>
       <table>
-        <tr>
-          <th>Date</th>
-          <th>Version</th>
-          <th>Notes</th>
-          <th>Documentation</th>
-          <th>Source</th>
-          <th>Binary</th>
-        </tr>
-        <tr id="release-master">
-          <td>Current</td>
-          <td>master</td>
-          <td>(wip)</td>
-          <td><a href="/documentation/master">docs</a></td>
-          <td><a href="https://github.com/zig-lang/zig">git clone</a></td>
-          <td>
-            <a href="https://ci.appveyor.com/project/andrewrk/zig-d3l86/history?branch=master" title="Find the latest successful build, click on ARTIFACTS, and download the .zip file.">Windows x86_64 CI build</a><br>
-            <a href="https://ziglang.org/builds/zig-linux-x86_64-master.tar.xz">Linux x86_64 CI build</a>
-          </td>
-        </tr>
-        <tr id="release-0.2.0">
-          <td>2018-03-15</td>
-          <td>0.2.0</td>
-          <td><a href="0.2.0/release-notes.html">Release Notes</a></td>
-          <td><a href="/documentation/0.2.0">docs</a></td>
-          <td><a href="/download/0.2.0/zig-0.2.0.tar.xz">zig-0.2.0.tar.xz</a></td>
-          <td>
-            <a href="/download/0.2.0/zig-win64-0.2.0.zip">zig-win64-0.2.0.zip</a><br>
-            <a href="/download/0.2.0/zig-linux-x86_64-0.2.0.tar.xz">zig-linux-x86_64-0.2.0.tar.xz</a>
-          </td>
-        </tr>
-        <tr id="release-0.1.1">
-          <td>2017-10-17</td>
-          <td>0.1.1</td>
-          <td><a href="0.1.1/release-notes.html">Release Notes</a></td>
-          <td><a href="/documentation/0.1.1">docs</a></td>
-          <td><a href="/download/0.1.1/zig-0.1.1.tar.xz">zig-0.1.1.tar.xz</a></td>
-          <td><a href="/download/0.1.1/zig-win64-0.1.1.zip">zig-win64-0.1.1.zip</a></td>
-        </tr>
+        <col width="20%">
+        <col width="10%">
+        <col width="10%">
+        <col width="10%">
+        <thead>
+          <th>Filename</th>
+          <th>Kind</th>
+          <th>Os</th>
+          <th>Arch</th>
+          <th>Size</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/zig-lang/zig/archive/master.zip">master.zip</a></td>
+            <td>Source</td>
+            <td>Any</td>
+            <td>Any</td>
+            <td>~2MiB</td>
+          </tr>
+          <tr>
+            <td><a href="https://ziglang.org/builds/zig-linux-x86_64-master.tar.xz">zig-linux-x86_64-master.tar.xz</a></td>
+            <td>Binary</td>
+            <td>Linux</td>
+            <td>x86-64</td>
+            <td>~25MiB</td>
+          </tr>
+          <tr>
+            <td title="Find the latest successful build, click on ARTIFACTS, and download the .zip file.">
+              <a href="https://ci.appveyor.com/project/andrewrk/zig-d3l86/history?branch=master">windows-x86_64-master.zip</a></td>
+            <td>Binary</td>
+            <td>Windows</td>
+            <td>x86-64</td>
+            <td>~25MiB</td>
+          </tr>
+        </tbody>
       </table>
+
+      <h2 id="release-0.2.0">0.2.0 (latest)</h2>
+      <ul>
+        <li>2018-03-15</li>
+        <li><a href="0.2.0/release-notes.html">Release Notes</a></li>
+        <li><a href="/documentation/0.2.0">Documentation</a></li>
+      </ul>
+      <table>
+        <col width="20%">
+        <col width="10%">
+        <col width="10%">
+        <col width="10%">
+        <col width="40%">
+        <thead>
+          <th>Filename</th>
+          <th>Kind</th>
+          <th>Os</th>
+          <th>Arch</th>
+          <th>Size</th>
+          <th>Sha256</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://ziglang.org/builds/zig-0.2.0.tar.xz">zig-0.2.0.tar.xz</a></td>
+            <td>Source</td>
+            <td>Any</td>
+            <td>Any</td>
+            <td>1.90MiB</td>
+            <td class="code">29c9beb172737f4d5019b88ceae829ae8bc6512fb4386cfbf895ae2b42aa6965</td>
+          </tr>
+          <tr>
+            <td><a href="https://ziglang.org/builds/zig-linux-x86_64-0.2.0.tar.xz">zig-linux-x86_64-0.2.0.tar.xz</a></td>
+            <td>Binary</td>
+            <td>Linux</td>
+            <td>x86-64</td>
+            <td>23.53MiB</td>
+            <td class="code">f8429d6c3288041cdc7cdd5df51b7c44cb94403ac3f0641ebfba9d34ef73b082</td>
+          </tr>
+          <tr>
+            <td><a href="https://ziglang.org/download/0.2.0/zig-win64-0.2.0.zip">zig-win64-0.2.0.zip</a></td>
+            <td>Binary</td>
+            <td>Windows</td>
+            <td>x86-64</td>
+            <td>20.58MiB</td>
+            <td class="code">4f8a2979941a1f081ec8e545cca0b72608c0db1c5a3fd377a94db40649dcd3d4</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="release-0.1.1">0.1.1</h2>
+      <ul>
+        <li>2017-10-17</li>
+        <li><a href="0.1.1/release-notes.html">Release Notes</a></li>
+        <li><a href="/documentation/0.1.1">Documentation</a></li>
+      </ul>
+      <table>
+        <col width="20%">
+        <col width="10%">
+        <col width="10%">
+        <col width="10%">
+        <col width="40%">
+        <thead>
+          <th>Filename</th>
+          <th>Kind</th>
+          <th>Os</th>
+          <th>Arch</th>
+          <th>Size</th>
+          <th>Sha256</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://ziglang.org/builds/zig-0.1.1.tar.xz">zig-0.1.1.tar.xz</a></td>
+            <td>Source</td>
+            <td>Any</td>
+            <td>Any</td>
+            <td>1.62MiB</td>
+            <td class="code">ffca0cfb263485287e19cc997b08701fcd5f24b700345bcdc3dd8074f5a104e0</td>
+          </tr>
+          <tr>
+            <td><a href="https://ziglang.org/download/0.1.1/zig-win64-0.1.1.zip">zig-win64-0.1.1.zip</a></td>
+            <td>Binary</td>
+            <td>Windows</td>
+            <td>x86-64</td>
+            <td>19.30MiB</td>
+            <td class="code">6fc88bef531af7e567fe30bf60da1487b86833cbee84c7a2f3e317030aa5b660</td>
+          </tr>
+        </tbody>
+      </table>
+
+
       <br>
       <p>You can also <a href="https://github.com/zig-lang/zig/wiki/Install-Zig-from-a-Package-Manager">install Zig from a package manager</a>.
       <br>


### PR DESCRIPTION
Changes to the releases page to convery a bit more information. This will work a bit better as we provide more binaries/releases. I've pretty much modelled it off Go's releases page with some changes.

Let me know if this looks okay or you prefer something else.

# Old
![old](https://user-images.githubusercontent.com/4605603/39297280-34bf555a-4997-11e8-853a-ceb3baa41f12.png)

# New

![new](https://user-images.githubusercontent.com/4605603/39297290-3c9b0f1c-4997-11e8-88a8-78af4de2461d.png)
